### PR TITLE
Fix UniGet on OSX

### DIFF
--- a/src/UniGet/GithubPackage.cs
+++ b/src/UniGet/GithubPackage.cs
@@ -48,7 +48,7 @@ namespace UniGet
 
         public static string GetPackageCacheRoot()
         {
-            return Path.Combine(Environment.GetEnvironmentVariable("APPDATA"), "uniget");
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "uniget");
         }
 
         public static async Task<List<Tuple<string, SemVer.Version>>> FetchPackagesAsync(string owner, string repoName, string projectId, string userToken = null)

--- a/src/UniGet/NugetPackage.cs
+++ b/src/UniGet/NugetPackage.cs
@@ -7,7 +7,7 @@ namespace UniGet
     {
         public static string GetPackageCacheRoot()
         {
-            return Path.Combine(Environment.GetEnvironmentVariable("APPDATA"), "uniget", "nuget");
+            return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "uniget", "nuget");
         }
 
         public static Tuple<string, SemVer.Version> DownloadPackage(

--- a/src/UniGet/RemoveTool.cs
+++ b/src/UniGet/RemoveTool.cs
@@ -106,8 +106,8 @@ namespace UniGet
 
             if (ok && Directory.GetFiles(path).Any() == false)
             {
+                var metaFile = Path.GetFullPath(Path.Combine(path, "..", Path.GetFileName(path))) + ".meta";
                 Directory.Delete(path);
-                var metaFile = Path.Combine(path, "..", Path.GetFileName(path)) + ".meta";
                 if (File.Exists(metaFile))
                     File.Delete(metaFile);
                 return true;


### PR DESCRIPTION
Changed to use Environment.SpecialFolder.ApplicationData instead of readying Window's APPDATA environment variable.